### PR TITLE
Add FastAPI root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Bogucki Cards to połączenie gry przeglądarkowej oraz bota Discord, w której 
   ```bash
   uvicorn backend.main:app --reload
   ```
+  Po uruchomieniu odwiedź [http://localhost:8000/](http://localhost:8000/) aby
+  zobaczyć komunikat testowy `{"Hello": "CardCollectorGame Backend running!"}`.
 - **Testy**
   ```bash
   pytest -v

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,12 @@ from models import User
 
 app = FastAPI(title="Cardgame API")
 
+
+@app.get("/")
+async def read_root():
+    """Health check endpoint for quick verification."""
+    return {"Hello": "CardCollectorGame Backend running!"}
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
## Summary
- add `/` health check in `backend/main.py`
- mention the health check endpoint in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_684c05ee0e58832fb8b7c1f9af5ac0f5